### PR TITLE
Restore original desktop layout while keeping mobile fixes

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,55 +1,85 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>David Bramslev — Portfolio</title>
-  <link rel="stylesheet" href="style.css" />
-  <link rel="stylesheet" href="https://use.typekit.net/jvk3rir.css" />
-</head>
-<body>
-  <header class="site-header">
-  <div class="header-mail">
-      <a href="mailto:hello@davidbramslev.com" style="color:inherit;text-decoration:none;">hello@davidbramslev.com</a>
-    </div>
-  <h1 class="header-title">David Bramslev</h1>
-  </header>
-
-  <main>
-    <ul class="film-list">
-  <li data-video="https://player.vimeo.com/video/1031727140">OVER-WOKE</li>
-  <li data-video="https://player.vimeo.com/video/938143193">YOU LIKE DRUGS</li>
-  <li data-video="https://player.vimeo.com/video/933648961">WHERE DID I GO</li>
-  <li data-video="https://player.vimeo.com/video/877807338">EN LYCKLIG MAN</li>
-  <li data-video="https://player.vimeo.com/video/843287731">WHITE ANASTASIA</li>
-  <li data-video="https://player.vimeo.com/video/812782892">FEELINGS</li>
-  <li data-video="https://player.vimeo.com/video/812484130">KEVINS GOLD</li>
-  <li data-video="https://player.vimeo.com/video/875652237">COFFEE BREAK</li>
-    </ul>
-  </main>
-
-  <!-- Modal -->
-  <div id="modal" class="modal hidden">
-    <div class="modal-content">
-      <div class="video-wrapper">
-        <iframe id="videoFrame" src="" frameborder="0" allow="autoplay; fullscreen" allowfullscreen></iframe>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>David Bramslev — Portfolio</title>
+    <link rel="stylesheet" href="style.css" />
+    <link rel="stylesheet" href="https://use.typekit.net/jvk3rir.css" />
+  </head>
+  <body>
+    <header class="site-header">
+      <div class="header-mail">
+        <a href="mailto:hello@davidbramslev.com">hello@davidbramslev.com</a>
       </div>
-      <div id="filmInfo" class="film-info"></div>
-    </div>
-  </div>
+      <h1 class="header-title">David Bramslev</h1>
+    </header>
 
-  <script src="script.js"></script>
-  <div class="bottom-info">
-    Director, Screenwriter, Editor
-    <div class="subtitle">Currently based in Oslo/Copenhagen</div>
-    <div class="bottom-social" style="margin-top:24px;display:flex;justify-content:center;gap:16px;">
-      <a href="https://www.instagram.com/davidbramsl/" target="_blank" title="Instagram" rel="noopener noreferrer">
-        <img src="media/instagram.webp" alt="Instagram" style="width:32px;height:32px;object-fit:contain;" />
-      </a>
-      <a href="https://vimeo.com/bramslev" target="_blank" title="Vimeo" rel="noopener noreferrer">
-        <img src="media/vim.webp" alt="Vimeo" style="width:32px;height:32px;object-fit:contain;" />
-      </a>
+    <main>
+      <ul class="film-list">
+        <li data-video="https://player.vimeo.com/video/1031727140">
+          OVER-WOKE
+        </li>
+        <li data-video="https://player.vimeo.com/video/938143193">
+          YOU LIKE DRUGS
+        </li>
+        <li data-video="https://player.vimeo.com/video/933648961">
+          WHERE DID I GO
+        </li>
+        <li data-video="https://player.vimeo.com/video/877807338">
+          EN LYCKLIG MAN
+        </li>
+        <li data-video="https://player.vimeo.com/video/843287731">
+          WHITE ANASTASIA
+        </li>
+        <li data-video="https://player.vimeo.com/video/812782892">FEELINGS</li>
+        <li data-video="https://player.vimeo.com/video/812484130">
+          KEVINS GOLD
+        </li>
+        <li data-video="https://player.vimeo.com/video/875652237">
+          COFFEE BREAK
+        </li>
+      </ul>
+    </main>
+
+    <!-- Modal -->
+    <div id="modal" class="modal hidden">
+      <div class="modal-content">
+        <div class="video-wrapper">
+          <iframe
+            id="videoFrame"
+            src=""
+            frameborder="0"
+            allow="autoplay; fullscreen"
+            allowfullscreen
+          ></iframe>
+        </div>
+        <div id="filmInfo" class="film-info"></div>
+      </div>
     </div>
-  </div>
-</body>
+
+    <script src="script.js"></script>
+    <div class="bottom-info">
+      Director, Screenwriter, Editor
+      <div class="subtitle">Currently based in Oslo/Copenhagen</div>
+      <div class="bottom-social">
+        <a
+          href="https://www.instagram.com/davidbramsl/"
+          target="_blank"
+          title="Instagram"
+          rel="noopener noreferrer"
+        >
+          <img src="media/instagram.webp" alt="Instagram" />
+        </a>
+        <a
+          href="https://vimeo.com/bramslev"
+          target="_blank"
+          title="Vimeo"
+          rel="noopener noreferrer"
+        >
+          <img src="media/vim.webp" alt="Vimeo" />
+        </a>
+      </div>
+    </div>
+  </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -11,29 +11,38 @@ document.addEventListener("DOMContentLoaded", () => {
     "WHERE DID I GO": "media/WhereDidIGo.jpg",
     "EN LYCKLIG MAN": "media/EnLyckligman5.png",
     "WHITE ANASTASIA": "media/WHITEANASTASIA3.png",
-    "FEELINGS": "media/Feelings1.PNG",
+    FEELINGS: "media/Feelings1.PNG",
     "KEVINS GOLD": "media/KevinsGold1.jpeg",
-    "COFFEE BREAK": "media/CoffeeBreak1.JPG"
+    "COFFEE BREAK": "media/CoffeeBreak1.JPG",
   };
 
   function isMobile() {
     return window.innerWidth <= 768;
   }
 
+  function clearBackground() {
+    body.classList.remove("bg-cover");
+    body.style.backgroundImage = "";
+    body.style.backgroundSize = "";
+    body.style.backgroundPosition = "";
+    body.style.backgroundRepeat = "";
+  }
+
   function setBackgroundFor(title) {
     const img = bgImages[title];
     if (img) {
+      body.classList.add("bg-cover");
       body.style.backgroundImage = `url('${img}')`;
       body.style.backgroundSize = "cover";
       body.style.backgroundPosition = "center";
       body.style.backgroundRepeat = "no-repeat";
     } else {
-      body.style.backgroundImage = "";
+      clearBackground();
     }
   }
 
   // --- Desktop behavior: hover preview + click opens modal
-  filmItems.forEach(item => {
+  filmItems.forEach((item) => {
     item.addEventListener("click", () => {
       const videoUrl = item.getAttribute("data-video");
       const infoText = item.getAttribute("data-info") || "";
@@ -55,8 +64,10 @@ document.addEventListener("DOMContentLoaded", () => {
     item.addEventListener("mouseleave", () => {
       if (isMobile() || !modal.classList.contains("hidden")) return;
       setTimeout(() => {
-        const stillHovering = Array.from(filmItems).some(el => el.matches(":hover"));
-        if (!stillHovering) body.style.backgroundImage = "";
+        const stillHovering = Array.from(filmItems).some((el) =>
+          el.matches(":hover"),
+        );
+        if (!stillHovering) clearBackground();
         item.classList.remove("mobile-hover");
       }, 150);
     });
@@ -69,19 +80,22 @@ document.addEventListener("DOMContentLoaded", () => {
     if (!isMobile()) return;
 
     // When >60% of the li is visible, treat it as active
-    observer = new IntersectionObserver(entries => {
-      entries.forEach(entry => {
-        if (entry.intersectionRatio > 0.6) {
-          // clear previous
-          filmItems.forEach(i => i.classList.remove("mobile-hover"));
-          entry.target.classList.add("mobile-hover");
-          const title = entry.target.textContent.trim().toUpperCase();
-          setBackgroundFor(title);
-        }
-      });
-    }, { threshold: [0.6] });
+    observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.intersectionRatio > 0.6) {
+            // clear previous
+            filmItems.forEach((i) => i.classList.remove("mobile-hover"));
+            entry.target.classList.add("mobile-hover");
+            const title = entry.target.textContent.trim().toUpperCase();
+            setBackgroundFor(title);
+          }
+        });
+      },
+      { threshold: [0.6] },
+    );
 
-    filmItems.forEach(item => observer.observe(item));
+    filmItems.forEach((item) => observer.observe(item));
   }
 
   // initialize (and re-init on resize/orientation change)
@@ -94,7 +108,7 @@ document.addEventListener("DOMContentLoaded", () => {
     if (e.target === modal) {
       modal.classList.add("hidden");
       videoFrame.src = "";
-      body.style.backgroundImage = "";
+      clearBackground();
     }
   });
 });

--- a/style.css
+++ b/style.css
@@ -1,17 +1,15 @@
-/* Highlight active item on mobile */
-.film-list li.mobile-hover {
-  color: #002bff;
-  letter-spacing: 2px;
-  font-weight: 500;
-  transition: color 0.3s, letter-spacing 0.3s;
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  font-family: "proxima-nova", sans-serif;
+  background: #ffffff;
+  background-attachment: fixed;
+  color: #111;
+  overflow-x: hidden;
 }
-.bottom-social img {
-  filter: none;
-  transition: filter 0.3s;
-}
-.bg-cover .bottom-social img {
-  filter: brightness(0) saturate(100%) invert(18%) sepia(100%) saturate(7490%) hue-rotate(222deg) brightness(100%) contrast(100%);
-}
+
 .site-header {
   position: fixed;
   top: 0;
@@ -21,97 +19,49 @@
   background: transparent;
   box-shadow: none;
   min-height: 90px;
+  padding: 12px 20px;
 }
-.header-icons {
-  position: absolute;
-  top: 32px;
-  left: 12px;
-  display: flex;
-  gap: 8px;
-}
+
 .header-mail {
   position: absolute;
   top: 32px;
   right: 3%;
-  font-size: 12.6px;
-  color: #1a237e;
-}
-.header-title {
-  margin-top: 32px;
-}
-main {
-  margin-top: 120px;
-}
-header {
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  z-index: 1000;
-  background: #fff;
-  box-shadow: 0 2px 8px rgba(0,0,0,0.03);
-}
-main {
-  margin-top: 120px;
-}
-main {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  min-height: 80vh;
-}
-/* Bottom info text at end of page */
-.bottom-info {
-  width: 100%;
-  text-align: center;
-  font-family: inherit;
-  font-size: 0.99rem;
+  font-size: 14px;
   color: #002bff;
-  background: transparent;
-  margin: 10vh 0 0 0;
-  padding-bottom: 400px;
-}
-.bottom-info .subtitle {
-  margin-top: 8px;
-  font-size: 0.9rem;
-  color: #222;
-}
-body {
-  margin: 0;
-  overflow-x: hidden;
-  overflow-x: hidden;
-  font-family: "proxima-nova", sans-serif;
-  background: #ffffff;
-  background-attachment: fixed;
-  color: #111;
-  height: auto;
-  display: flex;
-  flex-direction: column;
 }
 
-header {
-  padding: 12px 20px;
+.header-mail a {
+  color: inherit;
+  text-decoration: none;
 }
 
-header h1 {
-  font-size: 25.2px;
+.header-mail a:hover,
+.header-mail a:focus {
+  text-decoration: underline;
+}
+
+.header-title {
+  margin: 32px auto 0;
+  font-size: 28px;
   font-weight: 400;
-  font-style: normal;
   letter-spacing: 0.5px;
   color: #002bff;
-  margin: 1% auto 0 auto;
   text-align: center;
   text-transform: capitalize;
-  font-family: 'seismic-latin-variable', sans-serif;
-  font-variation-settings: 'wght' 409, 'SEIS' 100;
+  font-family: "seismic-latin-variable", sans-serif;
+  font-variation-settings:
+    "wght" 409,
+    "SEIS" 100;
 }
 
 main {
   flex: 1;
-  overflow-y: auto;
+  margin-top: 120px;
   display: flex;
   justify-content: center;
   align-items: center;
+  min-height: 80vh;
+  overflow-y: auto;
 }
 
 .film-list {
@@ -122,33 +72,76 @@ main {
   display: flex;
   flex-wrap: nowrap;
   overflow-x: auto;
-  scrollbar-width: none; /* Firefox */
-  -ms-overflow-style: none;  /* IE and Edge */
+  scrollbar-width: none;
+  -ms-overflow-style: none;
 }
 
 .film-list::-webkit-scrollbar {
-  display: none; /* Chrome, Safari, Opera */
-  gap: 50px;
-  justify-content: flex-start;
+  display: none;
 }
 
 .film-list li {
-  font-size: 61.56px;
+  font-size: 72px;
   font-weight: 500;
   padding: 0 50px;
   margin: 0;
   cursor: pointer;
-  transition: color 0.3s ease, letter-spacing 0.3s ease;
-  transform: translateY(-5%);
+  transition:
+    color 0.3s ease,
+    letter-spacing 0.3s ease;
 }
 
 .film-list li:hover {
-  color: #1a237e;
   color: #002bff;
   letter-spacing: 2px;
 }
 
-/* Modal */
+.film-list li.mobile-hover {
+  color: #002bff;
+  letter-spacing: 2px;
+  font-weight: 500;
+  transition:
+    color 0.3s ease,
+    letter-spacing 0.3s ease;
+}
+
+.bottom-info {
+  width: 100%;
+  text-align: center;
+  font-size: 1.21rem;
+  color: #000;
+  background: transparent;
+  margin: 10vh 0 0;
+  padding: 0 20px 400px;
+}
+
+.bottom-info .subtitle {
+  margin-top: 8px;
+  font-size: 1.1rem;
+  color: #000;
+}
+
+.bottom-social {
+  margin-top: 24px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 16px;
+}
+
+.bottom-social img {
+  width: 32px;
+  height: 32px;
+  object-fit: contain;
+  filter: none;
+  transition: filter 0.3s;
+}
+
+body.bg-cover .bottom-social img {
+  filter: brightness(0) saturate(100%) invert(18%) sepia(100%) saturate(7490%)
+    hue-rotate(222deg) brightness(100%) contrast(100%);
+}
+
 .modal {
   position: fixed;
   top: 0;
@@ -181,8 +174,7 @@ main {
 .video-wrapper {
   border: none;
   position: relative;
-
-  padding-bottom: 56.25%; /* 16:9 */
+  padding-bottom: 56.25%;
   height: 0;
 }
 
@@ -197,182 +189,79 @@ main {
 }
 
 .film-info {
-  font-size: 21.6px;
+  font-size: 24px;
   font-weight: 500;
   white-space: nowrap;
   cursor: pointer;
-  transition: color 0.3s ease, letter-spacing 0.3s ease;
-  /* 📱 MOBILE STYLES - REPLACE BOTH EXISTING MEDIA QUERIES */
+  transition:
+    color 0.3s ease,
+    letter-spacing 0.3s ease;
+}
+
 @media (max-width: 768px) {
-  /* Base mobile reset */
-  html, body {
-    height: auto !important;
-    overflow-y: auto !important;
-    overflow-x: hidden !important;
-    background: #ffffff !important;
-    font-size: 16px !important;
-    margin: 0 !important;
-    padding: 0 !important;
-  }
-
-  /* Header - compact and fixed */
-  header {
-    position: fixed !important;
-    top: 0 !important;
-    left: 0 !important;
-    width: 100% !important;
-    min-height: 50px !important;
-    padding: 10px 15px !important;
-    background: #fff !important;
-    z-index: 1000 !important;
-    box-shadow: 0 1px 4px rgba(0,0,0,0.05) !important;
-    box-sizing: border-box !important;
-    display: flex !important;
-    align-items: center !important;
-    justify-content: space-between !important;
-  }
-
-  .header-title {
-    font-size: 18px !important;
-    font-weight: 400 !important;
-    letter-spacing: 0.5px !important;
-    color: #002bff !important;
-    margin: 0 !important;
-    text-align: left !important;
-    flex: 1 !important;
-    font-family: 'seismic-latin-variable', sans-serif !important;
-    font-variation-settings: 'wght' 409, 'SEIS' 100 !important;
+  .site-header {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    padding: 20px;
+    min-height: auto;
   }
 
   .header-mail {
-    font-size: 11px !important;
-    color: #1a237e !important;
-    margin: 0 !important;
-    text-align: right !important;
-    white-space: nowrap !important;
-    max-width: 50% !important;
-    flex: 0 0 auto !important;
+    position: static;
+    order: 2;
+    font-size: 12px;
   }
 
-  /* Main content */
+  .header-title {
+    margin: 0;
+    font-size: 26px;
+  }
+
   main {
-    margin-top: 60px !important;
-    padding: 30px 20px 120px 20px !important;
-    display: block !important;
-    min-height: calc(100vh - 60px) !important;
-    box-sizing: border-box !important;
+    margin-top: 160px;
+    align-items: flex-start;
+    padding: 0 20px 80px;
+    min-height: auto;
   }
 
-  /* Film list - CLEAN VERTICAL STACK */
   .film-list {
-    list-style: none !important;
-    padding: 0 !important;
-    margin: 0 !important;
-    width: 100% !important;
-    display: flex !important;
-    flex-direction: column !important;
-    gap: 40px !important;
-    overflow: visible !important;
-    scrollbar-width: none !important;
+    flex-direction: column;
+    gap: 32px;
+    overflow: visible;
+    align-items: center;
   }
 
   .film-list li {
-    font-size: 32px !important;
-    font-weight: 500 !important;
-    font-family: 'seismic-latin-variable', sans-serif !important;
-    font-variation-settings: 'wght' 409, 'SEIS' 100 !important;
-    padding: 0 !important;
-    margin: 0 !important;
-    cursor: pointer !important;
-    text-align: left !important;
-    letter-spacing: 0.5px !important;
-    line-height: 1.1 !important;
-    color: #111 !important;
-    border-bottom: none !important;
-    transition: all 0.3s ease !important;
-    transform: none !important;
-    white-space: normal !important;
-    position: relative !important;
-    flex: none !important; /* Prevent flex shrinking */
+    padding: 0;
+    font-size: 42px;
+    letter-spacing: 0.5px;
+    text-align: center;
+    width: 100%;
   }
 
-  /* Active state */
-  .film-list li.mobile-hover,
-  .film-list li:hover {
-    color: #002bff !important;
-    letter-spacing: 1px !important;
-    font-weight: 600 !important;
-  }
-
-  /* Modal */
-  .modal {
-    background: rgba(0,0,0,0.95) !important;
-    padding: 10px !important;
-  }
-
-  .modal-content {
-    width: 100% !important;
-    max-width: none !important;
-    height: 100vh !important;
-    display: flex !important;
-    flex-direction: column !important;
-  }
-
-  .video-wrapper {
-    flex: 1 !important;
-    margin-bottom: 15px !important;
-  }
-
-  .video-wrapper iframe {
-    border-radius: 0 !important;
-    height: 100% !important;
-  }
-
-  .film-info {
-    font-size: 16px !important;
-    color: #fff !important;
-    text-align: center !important;
-    padding: 10px !important;
-    background: rgba(0,0,0,0.4) !important;
-  }
-
-  /* Bottom info */
   .bottom-info {
-    width: 100% !important;
-    text-align: center !important;
-    font-family: inherit !important;
-    font-size: 13px !important;
-    color: #002bff !important;
-    background: transparent !important;
-    margin: 50px 0 0 0 !important;
-    padding: 20px 0 !important;
-    border-top: 1px solid #eee !important;
-  }
-
-  .bottom-info .subtitle {
-    margin-top: 6px !important;
-    font-size: 12px !important;
-    color: #666 !important;
-  }
-
-  /* Hide desktop elements */
-  .header-icons {
-    display: none !important;
-  }
-
-  /* Kill any other desktop transforms */
-  .film-list li {
-    transform: translateY(0) !important;
+    margin-top: 80px;
+    padding-bottom: 220px;
   }
 }
 
-/* Extra small screens */
 @media (max-width: 480px) {
-  .film-list li {
-    font-size: 28px !important;
+  body {
+    font-size: 16px;
   }
-  
-  .film-list {
-    gap: 35px !important;
+
+  .header-title {
+    font-size: 24px;
+  }
+
+  .header-mail {
+    font-size: 13px;
+  }
+
+  .film-list li {
+    font-size: 38px;
   }
 }


### PR DESCRIPTION
## Summary
- revert the header markup so the email and name render with the original desktop placement
- reset the desktop typography, spacing, and footer treatments to match the initial design while retaining the social icon styling
- keep the responsive media query that stacks the film list on phones to ensure vertical scrolling works on small screens

## Testing
- npx prettier --check index.html style.css script.js

------
https://chatgpt.com/codex/tasks/task_e_68dd3bc25fec832b94352fbb4d21625d